### PR TITLE
feat: 경매글 생성 시, 배치 서버에 카프카 consumer을 통해 스케줄링 등록 및 Qualifier을 통해 bean 명시화

### DIFF
--- a/src/main/java/com/meetplus/batch/BatchApplication.java
+++ b/src/main/java/com/meetplus/batch/BatchApplication.java
@@ -3,10 +3,15 @@ package com.meetplus.batch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class BatchApplication {
 
 	public static void main(String[] args) {
+		// application 전체 timezone을 UTC로 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
 		SpringApplication.run(BatchApplication.class, args);
 	}
 

--- a/src/main/java/com/meetplus/batch/config/ScheduleConfig.java
+++ b/src/main/java/com/meetplus/batch/config/ScheduleConfig.java
@@ -1,10 +1,19 @@
 package com.meetplus.batch.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class ScheduleConfig {
-
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);  // 스레드 풀 크기 설정
+        scheduler.setThreadNamePrefix("task-scheduler-");  // 스레드 이름 접두사 설정
+        scheduler.initialize();
+        return scheduler;
+    }
 }

--- a/src/main/java/com/meetplus/batch/kafka/KafkaConsumerCluster.java
+++ b/src/main/java/com/meetplus/batch/kafka/KafkaConsumerCluster.java
@@ -1,0 +1,48 @@
+package com.meetplus.batch.kafka;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+
+import com.meetplus.batch.kafka.dto.NewAuctionPostDto;
+import com.meetplus.batch.schedule.BeforeEventStartSchedule;
+import com.meetplus.batch.state.ScheduleTimeEnum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaConsumerCluster {
+
+    private final KafkaProducerCluster producer;
+    private final BeforeEventStartSchedule beforeEventStartSchedule;
+
+    @KafkaListener(topics = Topics.Constant.AUCTION_POST_SERVICE, groupId = "${spring.kafka.consumer.group-id}")
+    public void eventStart(@Payload LinkedHashMap<String, Object> message,
+        @Headers MessageHeaders messageHeaders) {
+        log.info("consumer: success >>> message: {}, headers: {}", message.toString(),
+            messageHeaders);
+
+        //message를 NewAuctionPostDto 변환
+        NewAuctionPostDto newAuctionPostDto = NewAuctionPostDto.builder()
+            .auctionUuid(message.get("auctionUuid").toString())
+            .eventStartTime(LocalDateTime.parse(message.get("eventStartTime").toString()))
+            .build();
+
+        log.info("consumer: success >>> newAuctionPostDto: {}", newAuctionPostDto.toString());
+
+        // 스케줄러 등록
+        //Todo
+        // 실제 테스트가 필요
+        beforeEventStartSchedule.scheduleJob(newAuctionPostDto);
+    }
+
+}

--- a/src/main/java/com/meetplus/batch/kafka/KafkaConsumerCluster.java
+++ b/src/main/java/com/meetplus/batch/kafka/KafkaConsumerCluster.java
@@ -2,6 +2,8 @@ package com.meetplus.batch.kafka;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
@@ -31,10 +33,15 @@ public class KafkaConsumerCluster {
         log.info("consumer: success >>> message: {}, headers: {}", message.toString(),
             messageHeaders);
 
+        // 시간 형식 지정
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse(message.get("eventStartTime").toString(), formatter);
+        LocalDateTime eventStartTime = offsetDateTime.toLocalDateTime();
+
         //message를 NewAuctionPostDto 변환
         NewAuctionPostDto newAuctionPostDto = NewAuctionPostDto.builder()
             .auctionUuid(message.get("auctionUuid").toString())
-            .eventStartTime(LocalDateTime.parse(message.get("eventStartTime").toString()))
+            .eventStartTime(eventStartTime)
             .build();
 
         log.info("consumer: success >>> newAuctionPostDto: {}", newAuctionPostDto.toString());

--- a/src/main/java/com/meetplus/batch/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/meetplus/batch/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,61 @@
+package com.meetplus.batch.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, Object> pushEntityConsumerFactory() {
+        JsonDeserializer<Object> deserializer = gcmPushEntityJsonDeserializer();
+        return new DefaultKafkaConsumerFactory<>(
+            consumerFactoryConfig(deserializer),
+            new StringDeserializer(),
+            deserializer);
+    }
+
+    private Map<String, Object> consumerFactoryConfig(JsonDeserializer<Object> deserializer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return props;
+    }
+
+    private JsonDeserializer<Object> gcmPushEntityJsonDeserializer() {
+        JsonDeserializer<Object> deserializer = new JsonDeserializer<>(Object.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(true);
+        return deserializer;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object>
+    kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(pushEntityConsumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/meetplus/batch/kafka/KafkaProducerCluster.java
+++ b/src/main/java/com/meetplus/batch/kafka/KafkaProducerCluster.java
@@ -1,0 +1,31 @@
+package com.meetplus.batch.kafka;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMessage(String topicName, Object object) {
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(topicName, object);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("producer: success >>> message: {}, offset: {}",
+                    result.getProducerRecord().value().toString(),
+                    result.getRecordMetadata().offset());
+            } else {
+                log.info("producer: failure >>> message: {}", ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/meetplus/batch/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/meetplus/batch/kafka/KafkaProducerConfig.java
@@ -1,0 +1,33 @@
+package com.meetplus.batch.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/meetplus/batch/kafka/Topics.java
+++ b/src/main/java/com/meetplus/batch/kafka/Topics.java
@@ -1,0 +1,23 @@
+package com.meetplus.batch.kafka;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Topics {
+    NOTIFICATION_SERVICE(Constant.NOTIFICATION_SERVICE),
+    CHAT_SERVICE(Constant.CHAT_SERVICE),
+    AUCTION_POST_SERVICE(Constant.AUCTION_POST_SERVICE),
+    PAYMENT_SERVICE(Constant.PAYMENT_SERVICE)
+    ;
+
+    public static class Constant {
+        public static final String NOTIFICATION_SERVICE = "alarm-topic";
+        public static final String CHAT_SERVICE = "chat-topic";
+        public static final String AUCTION_POST_SERVICE = "new-auction-post-topic";
+        public static final String PAYMENT_SERVICE = "event-preview-topic";
+    }
+
+    private final String topic;
+}

--- a/src/main/java/com/meetplus/batch/kafka/dto/EventPreviewDto.java
+++ b/src/main/java/com/meetplus/batch/kafka/dto/EventPreviewDto.java
@@ -1,0 +1,12 @@
+package com.meetplus.batch.kafka.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class EventPreviewDto {
+    private String auctionUuid;
+}

--- a/src/main/java/com/meetplus/batch/kafka/dto/NewAuctionPostDto.java
+++ b/src/main/java/com/meetplus/batch/kafka/dto/NewAuctionPostDto.java
@@ -1,0 +1,15 @@
+package com.meetplus.batch.kafka.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@ToString
+public class NewAuctionPostDto {
+    private String auctionUuid;
+    private LocalDateTime eventStartTime;
+}

--- a/src/main/java/com/meetplus/batch/schedule/BeforeEventStartJob.java
+++ b/src/main/java/com/meetplus/batch/schedule/BeforeEventStartJob.java
@@ -1,0 +1,56 @@
+package com.meetplus.batch.schedule;
+
+import com.meetplus.batch.kafka.KafkaProducerCluster;
+import com.meetplus.batch.kafka.Topics;
+import com.meetplus.batch.kafka.dto.EventPreviewDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class BeforeEventStartJob {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final KafkaProducerCluster producer;
+
+    @Bean
+    @Qualifier("eventPreviewStep")
+    public Step eventPreviewStep() {
+        return new StepBuilder("beforeEventStartStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    // JobParameters에서 auctionUuid 추출
+                    Map<String, Object> jobParameters = chunkContext.getStepContext().getJobParameters();
+                    String auctionUuid = String.valueOf(jobParameters.get("auctionUuid"));
+
+                    // kafka 메세지 전송
+                    producer.sendMessage(Topics.Constant.PAYMENT_SERVICE,
+                            EventPreviewDto.builder().auctionUuid(auctionUuid).build());
+
+                    log.info("Executing before event start job with auctionUuid: {}", auctionUuid);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    @Qualifier("eventPreviewJob")
+    public Job eventPreviewJob(@Qualifier("eventPreviewStep") Step beforeEventStartStep) {
+        return new JobBuilder("beforeEventStartJob", jobRepository)
+                .start(beforeEventStartStep)
+                .build();
+    }
+}

--- a/src/main/java/com/meetplus/batch/schedule/BeforeEventStartSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/BeforeEventStartSchedule.java
@@ -1,0 +1,65 @@
+package com.meetplus.batch.schedule;
+
+import com.meetplus.batch.kafka.dto.NewAuctionPostDto;
+import com.meetplus.batch.state.ScheduleTimeEnum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class BeforeEventStartSchedule {
+    private final JobLauncher jobLauncher;
+    private final Job beforeEventStartJob;
+    private final ThreadPoolTaskScheduler taskScheduler;
+
+    public BeforeEventStartSchedule(JobLauncher jobLauncher,
+                                    @Qualifier("eventPreviewJob") Job beforeEventStartJob,
+                                    ThreadPoolTaskScheduler taskScheduler) {
+        this.jobLauncher = jobLauncher;
+        this.beforeEventStartJob = beforeEventStartJob;
+        this.taskScheduler = taskScheduler;
+    }
+
+    public void scheduleJob(NewAuctionPostDto newAuctionPostDto) {
+        // 실행 시간 설정
+        LocalDateTime executionTime = newAuctionPostDto.getEventStartTime()
+                .plusHours(ScheduleTimeEnum.BEFORE_EVENT_START.getTime());
+        log.info("Scheduling job to run at >>> {}", executionTime);
+
+        // delay가 0이 되면 Job 실행
+        long delay = Duration.between(LocalDateTime.now(), executionTime).toMillis();
+
+        // delay가 음수인 경우 즉시 실행
+        if (delay < 0) {
+            log.warn("Execution time is in the past. Job will be executed immediately.");
+            delay = 0;
+        }
+
+        // 지정한 시간에 작업 실행하도록 스케줄링
+        taskScheduler.schedule(() -> {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("beforeEventStartTime", String.valueOf(System.currentTimeMillis()))
+                    .addString("auctionUuid", newAuctionPostDto.getAuctionUuid())
+                    .toJobParameters();
+
+            try {
+                jobLauncher.run(beforeEventStartJob, jobParameters);
+            } catch (JobExecutionAlreadyRunningException | JobRestartException |
+                    JobInstanceAlreadyCompleteException | JobParametersInvalidException e) {
+                log.error("Job Execution failed >>> {}", e.getMessage());
+            }
+        }, new Date(System.currentTimeMillis() + delay));       // 작업이 시작될 시간 설정
+    }
+}

--- a/src/main/java/com/meetplus/batch/schedule/BeforeEventStartSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/BeforeEventStartSchedule.java
@@ -39,7 +39,10 @@ public class BeforeEventStartSchedule {
         log.info("Scheduling job to run at >>> {}", executionTime);
 
         // delay가 0이 되면 Job 실행
-        long delay = Duration.between(LocalDateTime.now(), executionTime).toMillis();
+        //todo
+        // 지금은 메시지 받고 5초 뒤 작동하도록 진행했으나 실제로는 밑 주석으로 진행해야 한다.
+//        long delay = Duration.between(LocalDateTime.now(), executionTime).toMillis();
+        long delay = Duration.between(LocalDateTime.now(), LocalDateTime.now().plusSeconds(5)).toMillis();
 
         // delay가 음수인 경우 즉시 실행
         if (delay < 0) {

--- a/src/main/java/com/meetplus/batch/schedule/PaymentCancelJob.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentCancelJob.java
@@ -1,4 +1,4 @@
-package com.meetplus.batch;
+package com.meetplus.batch.schedule;
 
 import com.meetplus.batch.common.PaymentStatus;
 import com.meetplus.batch.domain.Payment;
@@ -17,6 +17,7 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -79,6 +80,7 @@ public class PaymentCancelJob {
     }
 
     @Bean
+    @Qualifier("updatePaymentStatusStep")
     public Step updatePaymentStatusStep() {
         return new StepBuilder("updatePaymentStatusStep", jobRepository)
             .<Payment, Payment>chunk(10, transactionManager)
@@ -89,7 +91,8 @@ public class PaymentCancelJob {
     }
 
     @Bean
-    public Job updatePaymentStatusJob(Step updatePaymentStatusStep) {
+    @Qualifier("updatePaymentStatusJob")
+    public Job updatePaymentStatusJob(@Qualifier("updatePaymentStatusStep") Step updatePaymentStatusStep) {
         return new JobBuilder("updatePaymentStatusJob", jobRepository)
             .start(updatePaymentStatusStep)
             .build();

--- a/src/main/java/com/meetplus/batch/schedule/PaymentCancelSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentCancelSchedule.java
@@ -13,12 +13,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-//@RequiredArgsConstructor
 public class PaymentCancelSchedule {
 
     private final JobLauncher jobLauncher;
-
-    //    @Qualifier("updatePaymentStatusJob")
     private final Job updatePaymentStatusJob;
 
     public PaymentCancelSchedule(JobLauncher jobLauncher,

--- a/src/main/java/com/meetplus/batch/schedule/PaymentCancelSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentCancelSchedule.java
@@ -1,4 +1,4 @@
-package com.meetplus.batch;
+package com.meetplus.batch.schedule;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -8,28 +8,37 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 public class PaymentCancelSchedule {
 
     private final JobLauncher jobLauncher;
 
+    //    @Qualifier("updatePaymentStatusJob")
     private final Job updatePaymentStatusJob;
+
+    public PaymentCancelSchedule(JobLauncher jobLauncher,
+                                 @Qualifier("updatePaymentStatusJob") Job updatePaymentStatusJob) {
+        this.jobLauncher = jobLauncher;
+        this.updatePaymentStatusJob = updatePaymentStatusJob;
+    }
+
 
     @Scheduled(cron = "0 0 2 * * ?")
     public void runJob() throws Exception {
         JobParameters jobParameters = new JobParametersBuilder()
-            .addString("paymentCancelTime", String.valueOf(System.currentTimeMillis()))  // 고유한 파라미터 추가
-            .toJobParameters();
+                .addString("paymentCancelTime", String.valueOf(System.currentTimeMillis()))  // 고유한 파라미터 추가
+                .toJobParameters();
 
         try {
             jobLauncher.run(updatePaymentStatusJob, jobParameters);
         } catch (JobExecutionAlreadyRunningException | JobRestartException |
                  JobInstanceAlreadyCompleteException e) {
-            System.out.println(e.getMessage());;
+            System.out.println(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/meetplus/batch/schedule/PaymentSumJob.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentSumJob.java
@@ -1,4 +1,4 @@
-package com.meetplus.batch;
+package com.meetplus.batch.schedule;
 
 import com.meetplus.batch.domain.Bank;
 import com.meetplus.batch.infrastructure.BankRepository;
@@ -19,6 +19,7 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -112,6 +113,7 @@ public class PaymentSumJob {
     }
 
     @Bean
+    @Qualifier("sumPaymentAmountPaidStep")
     public Step sumPaymentAmountPaidStep() {
         return new StepBuilder("sumPaymentAmountPaidStep", jobRepository)
             .<String, Bank>chunk(10, transactionManager)
@@ -122,7 +124,8 @@ public class PaymentSumJob {
     }
 
     @Bean
-    public Job sumPaymentAmountPaidJob(Step sumPaymentAmountPaidStep) {
+    @Qualifier("sumPaymentAmountPaidJob")
+    public Job sumPaymentAmountPaidJob(@Qualifier("sumPaymentAmountPaidStep") Step sumPaymentAmountPaidStep) {
         return new JobBuilder("sumPaymentAmountPaidJob", jobRepository)
             .start(sumPaymentAmountPaidStep)
             .build();

--- a/src/main/java/com/meetplus/batch/schedule/PaymentSumSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentSumSchedule.java
@@ -13,11 +13,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-//@RequiredArgsConstructor
 public class PaymentSumSchedule {
 
     private final JobLauncher jobLauncher;
-
     private final Job sumPaymentAmountPaidJob;
 
     public PaymentSumSchedule(JobLauncher jobLauncher,

--- a/src/main/java/com/meetplus/batch/schedule/PaymentSumSchedule.java
+++ b/src/main/java/com/meetplus/batch/schedule/PaymentSumSchedule.java
@@ -1,4 +1,4 @@
-package com.meetplus.batch;
+package com.meetplus.batch.schedule;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -8,16 +8,23 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 public class PaymentSumSchedule {
 
     private final JobLauncher jobLauncher;
 
     private final Job sumPaymentAmountPaidJob;
+
+    public PaymentSumSchedule(JobLauncher jobLauncher,
+                              @Qualifier("sumPaymentAmountPaidJob") Job sumPaymentAmountPaidJob) {
+        this.jobLauncher = jobLauncher;
+        this.sumPaymentAmountPaidJob = sumPaymentAmountPaidJob;
+    }
 
     @Scheduled(cron = "0 0 5 * * ?")
     public void runJob() throws Exception {

--- a/src/main/java/com/meetplus/batch/state/ScheduleTimeEnum.java
+++ b/src/main/java/com/meetplus/batch/state/ScheduleTimeEnum.java
@@ -1,0 +1,12 @@
+package com.meetplus.batch.state;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScheduleTimeEnum {
+    // 행사 시작 시간 12시간 전
+    BEFORE_EVENT_START(-12);
+    private final int time;
+}


### PR DESCRIPTION
#3 

카프카 컨슈머로 경매글 생성이 됐을 때 스케줄러 등록 로직을 작성합니다.
스케줄러 등록은 `행사 시작 시간`의 12시간 전에 Job 실행되도록 하였습니다.

Job 수행하는 행동은 카프카를 통해서 `결제 서비스`에 auctionUuid를 날립니다.

구현 과정에서 bean 관련 에러가 났습니다.
```
Parameter 0 of method eventPreviewJob in com.meetplus.batch.schedule.BeforeEventStartJob required a single bean, but 2 were found:
- updatePaymentStatusStep: defined by method 'updatePaymentStatusStep' in class path resource [com/meetplus/batch/PaymentCancelJob.class]
- eventPreviewStep: defined by method 'eventPreviewStep' in class path resource [com/meetplus/batch/schedule/BeforeEventStartJob.class]
```

bean 등록 할 때, Job과 Step에서 충돌이 나는 듯 해서 Qualifier로 명시해주어 에러 해결했습니다.

테스트 성공한 것을 기획팀장님과 확인했습니다.
테스트 환경에서는 경매글 생성 메시지를 받고 5초 뒤 결제 서비스로 메시지 송신하도록 로직을 작성했습니다.
실제 배포에서는 수정해야 합니다.