### PR TITLE
chore: kafka bootstrap-server 주입 설정 제거

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build docker image
-        run: docker build --build-arg KAFKA_BOOTSTRAP_SERVERS=${{ secrets.KAFKA_BOOTSTRAP_SERVERS }} -t ${{ secrets.DOCKERHUB_USERNAME }}/batch-server:latest -f Dockerfile .
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/batch-server:latest -f Dockerfile .
 
       - name: Push docker hub
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/batch-server:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN java -Djarmode=layertools -jar *.jar extract --destination target/extracted
 FROM bellsoft/liberica-openjdk-alpine:17
 VOLUME /tmp
 ARG EXTRACTED=/workspace/app/target/extracted
-ARG KAFKA_BOOTSTRAP_SERVERS
-ENV KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS}
 
 # Copy over the unpacked application
 COPY --from=build ${EXTRACTED}/dependencies/ ./


### PR DESCRIPTION
배포 컨테이너 실행시 kafka 연결이 안되는 오류가 발생하여
빌드 및 배포 시 kafka bootstrap-servers를 주입받는 부분을 제거했습니다.